### PR TITLE
Solved Most Stones Removed with Same Row or Column [LeetCode 947 | Graph | Medium] and update Readme.md

### DIFF
--- a/C++/Most-Stones-Removed-with-Same-Row-or-Column.cpp
+++ b/C++/Most-Stones-Removed-with-Same-Row-or-Column.cpp
@@ -1,0 +1,72 @@
+// C++ Union Find Solution
+// Time Complexity: O(V)
+// Space Complexity: O(V)
+
+class Solution {
+public:
+    vector<int> parent;
+    void initParent(int n) {
+        for (int i = 0; i <= n; ++i)
+        {
+            parent.push_back(i);
+        }
+    }
+
+    int find_parent(int& x) {
+        if (parent[x] == x) return x;
+        parent[x] = find_parent(parent[x]);
+        return parent[x];
+    }
+
+    bool unionEdge(int& x, int& y) {
+        int parent_x = find_parent(x);
+        int parent_y = find_parent(y);
+
+        if (parent_x == parent_y) return false;
+
+        if (parent_x > parent_y) parent[parent_x] = parent_y;
+        else parent[parent_y] = parent_x;
+
+        return true;
+    }
+
+    // map to store the index of first occurence of parent of the current index
+    unordered_map<int, int> rows, cols;
+
+    int removeStones(vector<vector<int>>& stones) {
+        initParent(stones.size());
+
+        for (int k = 0; k < stones.size(); k++) {
+            int i = stones[k][0], j = stones[k][1];
+            int par_i = INT_MAX, par_j = INT_MAX;
+
+            if (rows.find(i) == rows.end()) rows[i] = k;
+            else par_i = rows[i];
+
+            if (cols.find(j) == cols.end()) cols[j] = k;
+            else par_j = cols[j];
+
+            if (par_i != INT_MAX)
+                unionEdge(par_i, k);
+
+            if (par_j != INT_MAX)
+                unionEdge(par_j, k);
+        }
+
+        // ans represent number of disjoint sets
+        int ans = 0;
+        rows.clear(); cols.clear();
+        unordered_set<int> uniq_parents;
+
+        for (int k = 0; k < stones.size(); k++) {
+            int par_i = find_parent(k);
+
+            if (uniq_parents.find(par_i) == uniq_parents.end()) {
+                ans++;
+                uniq_parents.insert(par_i);
+            }
+        }
+
+        return stones.size() - ans;
+    }
+};

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Check out ---> [Sample PR](https://github.com/codedecks-in/LeetCode-Solutions/pu
 
 | 1192  | [Critical Connections in a Network](https://leetcode.com/problems/critical-connections-in-a-network/)                                   | [C++](./C++/Critical-Connections-in-a-Network.cpp)                        | _O(V+E)_ | _O(4V+E)_  | Hard     | Graph | Tarjan's Algorithm |
 | 785  | [Is Graph Bipartite?](https://leetcode.com/problems/is-graph-bipartite/)                                   | [C++](./C++/Is-Graph-Bipartite.cpp)                        | _O(V+E)_ | _O(V)_  | Medium     | Graph | BFS |
+| 947  | [Most Stones Removed with Same Row or Column](https://leetcode.com/problems/most-stones-removed-with-same-row-or-column/)                                   | [C++](./C++/Most-Stones-Removed-with-Same-Row-or-Column.cpp)         | _O(V)_ | _O(2V)_  | Medium     | Graph | Union Find |
 <br/>
 <div align="right">
     <b><a href="#algorithms">⬆️ Back to Top</a></b>


### PR DESCRIPTION
## Solution of  Most Stones Removed with Same Row or Column [[LeetCode 947](https://leetcode.com/problems/most-stones-removed-with-same-row-or-column/) | Graph | Medium] 

Addresses Issue #11 

Approach: Union Find Solution
Time Complexity: O(V)
Space Complexity: O(2V)

Posted solution on Discuss page in LeetCode: https://leetcode.com/problems/most-stones-removed-with-same-row-or-column/discuss/867364/c-union-find-solution-beats-90

The solution passes all test cases of LeetCode and beats 90% of the solutions

## Put check marks:
## Have you made changes in [README](https://github.com/codedecks-in/LeetCode-Solutions/blob/master/README.md) file ?
- [x] Added problem & solution under correct topic.
- [x] Specified Space & Time complexity.
- [x] Specified difficulty level, tag & Note(if any).

## Make sure all below guidelines are followed else PR will get Reject:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code so that it is easy to understand
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
