### PR TITLE
Generate PR for codedecks by solving any STACK/QUEUE section problem of LeetCode #90

### DIFF
--- a/Python/622-Design-Circular-Queue.py
+++ b/Python/622-Design-Circular-Queue.py
@@ -1,0 +1,80 @@
+"""
+Design your implementation of the circular queue. The circular queue is a linear data structure
+in which the operations are performed based on FIFO (First In First Out) principle
+and the last position is connected back to the first position to make a circle. It is also called "Ring Buffer".
+
+One of the benefits of the circular queue is that we can make use of the spaces in front of the queue.
+In a normal queue, once the queue becomes full, we cannot insert the next element
+even if there is a space in front of the queue. But using the circular queue, we can use the space to store new values.
+
+link - https://leetcode.com/problems/design-circular-queue/
+
+runtime - 72ms
+memory - 14.6 mb
+
+time complexity - O(n)
+space complexity - O(n)
+
+"""
+
+
+
+class MyCircularQueue:
+
+    def __init__(self, k: int):
+        """
+        Initialize your data structure here. Set the size of the queue to be k.
+        """
+        self.queue = [None] *k
+        self.head = 0
+        self.tail = -1
+        self.size = 0
+        self.max_size = k
+
+
+    def enQueue(self, value: int) -> bool:
+        """
+        Insert an element into the circular queue. Return true if the operation is successful.
+        """
+        if self.isFull():
+            return False
+        self.tail = (self.tail +1) % self.max_size
+        self.queue[self.tail] = value
+        self.size += 1
+        return True
+
+    def deQueue(self) -> bool:
+        """
+        Delete an element from the circular queue. Return true if the operation is successful.
+        """
+        if self.isEmpty():
+            return False
+        self.queue[self.head] = None
+        self.head = (self.head +1) % self.max_size
+        self.size -= 1
+        return True
+
+    def Front(self) -> int:
+        """
+        Get the front item from the queue.
+        """
+        return -1 if self.isEmpty() else self.queue[self.head]
+
+    def Rear(self) -> int:
+        """
+        Get the last item from the queue.
+        """
+        return -1 if self.isEmpty() else self.queue[self.tail]
+
+    def isEmpty(self) -> bool:
+        """
+        Checks whether the circular queue is empty or not.
+        """
+        return self.size == 0
+
+
+    def isFull(self) -> bool:
+        """
+        Checks whether the circular queue is full or not.
+        """
+        return self.size == self.max_size

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Check out ---> [Sample PR](https://github.com/codedecks-in/LeetCode-Solutions/pu
 | 933 | [Number of Recent Calls](https://leetcode.com/problems/number-of-recent-calls/) | [C++](./C++/Number-of-Recent-Calls.cpp) | _O(1)_ | _O(1)_ | Easy       | Queue, Sliding Window |
 | 641 | [Design Circular Deque](https://leetcode.com/problems/design-circular-deque/) | [Java](./Java/design-circular-deque.java/) | _O(n)_ | _O(n)_ | Medium       | Queue, Design |
 | 621 | [Task Scheduler ](https://leetcode.com/problems/task-scheduler/) | [Python](./Python/621-Task-Scheduler.py/)      | _O(n)_| _O(n)_| Medium  | Queue
+| 622 | [Design Circular Queue](https://leetcode.com/problems/design-circular-queue/) | [Python](./Python/622-Design-Circular-Queue.py/) | _O(n)_ | _O(n)_ | Medium | Queue
 
 <br/>
 <div align="right">


### PR DESCRIPTION
# Pull Request Template

## Description

link - https://leetcode.com/problems/design-circular-queue/

One of the benefits of the circular queue is that we can make use of the spaces in front of the queue. In a normal queue, once the queue becomes full, we cannot insert the next element even if there is a space in front of the queue. But using the circular queue, we can use the space to store new values.

Please include a summary of the problem and about the approach to solve the solution. Please also include relevant motivation and context.

code support
MyCircularQueue(k): Constructor, set the size of the queue to be k.
Front: Get the front item from the queue. If the queue is empty, return -1.
Rear: Get the last item from the queue. If the queue is empty, return -1.
enQueue(value): Insert an element into the circular queue. Return true if the operation is successful.
deQueue(): Delete an element from the circular queue. Return true if the operation is successful.
isEmpty(): Checks whether the circular queue is empty or not.
isFull(): Checks whether the circular queue is full or not.

List any dependencies that are required for this change.

## Put check marks:
## Have you made changes in [README](https://github.com/codedecks-in/LeetCode-Solutions/blob/master/README.md) file ?
- [x] Added problem & solution under correct topic.
- [x] Specified Space & Time complexity.
- [x] Specified difficulty level, tag & Note(if any).

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Make sure all below guidelines are followed else PR will get Reject:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code so that it is easy to understand
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
