### PR TITLE
added Find All Groups of Farmland

### DIFF
--- a/C++/C++/Find All Groups of Farmland
+++ b/C++/C++/Find All Groups of Farmland
@@ -1,0 +1,39 @@
+You are given a 0-indexed m x n binary matrix land where a 0 represents a hectare of forested land and a 1 represents a hectare of farmland.
+
+To keep the land organized, there are designated rectangular areas of hectares that consist entirely of farmland. These rectangular areas are called groups. No two groups are adjacent, meaning farmland in one group is not four-directionally adjacent to another farmland in a different group.
+
+land can be represented by a coordinate system where the top left corner of land is (0, 0) and the bottom right corner of land is (m-1, n-1). Find the coordinates of the top left and bottom right corner of each group of farmland. A group of farmland with a top left corner at (r1, c1) and a bottom right corner at (r2, c2) is represented by the 4-length array [r1, c1, r2, c2].
+
+Return a 2D array containing the 4-length arrays described above for each group of farmland in land. If there are no groups of farmland, return an empty array. You may return the answer in any order.
+
+*/
+
+
+class Solution {
+public:
+    vector<vector<int>> findFarmland(vector<vector<int>>& land) {
+        int m=land.size();
+        int n=land[0].size();
+        vector<vector<int>>ans;
+        for(int i=0;i<m;i++){
+            for(int j=0;j<n;j++){
+                if(land[i][j]==1){
+                pair<int,int>a=dfs(i,j,land);
+                ans.push_back({i,j,a.first,a.second});}
+            }
+        }
+        return ans;
+    }
+    pair<int,int>dfs(int i,int j,vector<vector<int>>&lnd){
+        if(i<0||j<0||i>=lnd.size()||j>=lnd[0].size()||lnd[i][j]!=1)
+            return {INT_MIN,INT_MIN};
+        lnd[i][j]=0;
+        vector<pair<int,int>>p;
+        p.push_back({i,j});
+        p.push_back(dfs(i+1,j,lnd));
+        p.push_back(dfs(i,j+1,lnd));
+        sort(p.begin(),p.end());
+        return p[p.size()-1];
+
+    }
+};

--- a/C++/Find All Groups of Farmland
+++ b/C++/Find All Groups of Farmland
@@ -1,0 +1,41 @@
+/*
+You are given a 0-indexed m x n binary matrix land where a 0 represents a hectare of forested land and a 1 represents a hectare of farmland.
+
+To keep the land organized, there are designated rectangular areas of hectares that consist entirely of farmland. These rectangular areas are called groups. No two groups are adjacent, meaning farmland in one group is not four-directionally adjacent to another farmland in a different group.
+
+land can be represented by a coordinate system where the top left corner of land is (0, 0) and the bottom right corner of land is (m-1, n-1). Find the coordinates of the top left and bottom right corner of each group of farmland. A group of farmland with a top left corner at (r1, c1) and a bottom right corner at (r2, c2) is represented by the 4-length array [r1, c1, r2, c2].
+
+Return a 2D array containing the 4-length arrays described above for each group of farmland in land. If there are no groups of farmland, return an empty array. You may return the answer in any order.
+
+*/
+
+
+class Solution {
+public:
+    vector<vector<int>> findFarmland(vector<vector<int>>& land) {
+        int m=land.size();
+        int n=land[0].size();
+        vector<vector<int>>ans;
+        for(int i=0;i<m;i++){
+            for(int j=0;j<n;j++){
+                if(land[i][j]==1){
+                pair<int,int>a=dfs(i,j,land);
+                ans.push_back({i,j,a.first,a.second});}
+            }
+        }
+        return ans;
+    }
+    pair<int,int>dfs(int i,int j,vector<vector<int>>&lnd){
+        if(i<0||j<0||i>=lnd.size()||j>=lnd[0].size()||lnd[i][j]!=1)
+            return {INT_MIN,INT_MIN};
+        lnd[i][j]=0;
+        vector<pair<int,int>>p;
+        p.push_back({i,j});
+        p.push_back(dfs(i+1,j,lnd));
+        p.push_back(dfs(i,j+1,lnd));
+        
+        sort(p.begin(),p.end());
+        return p[p.size()-1];
+        
+    }
+};


### PR DESCRIPTION
# Pull Request Template

## Description
Difficulty level:Medium
Tags:DFS,BFS,Array,Matrix

You are given a 0-indexed m x n binary matrix land where a 0 represents a hectare of forested land and a 1 represents a hectare of farmland.
 Find the coordinates of the top left and bottom right corner of each group of farmland. A group of farmland with a top left corner at (r1, c1) and a bottom right corner at (r2, c2) is represented by the 4-length array [r1, c1, r2, c2].

Solution Approach:
The key idea here to start a normal dfs with each of the most top-left corner of grid and visit all the adjacent nbrs which have value 1 means farmland.
Now we keep taking the maximum value of x and y from grid where we can reach.
Because we have rectanglular shapes maximum x and maximum y we can visit will be our most right-bottam cell which we can visit for the current iteration.

## Put check marks:
## Have you made changes in [README](https://github.com/codedecks-in/LeetCode-Solutions/blob/master/README.md) file ?
- [ &check;] Added problem & solution under correct topic.
- [x] Specified Space & Time complexity.
- [&check; ] Specified difficulty level, tag & Note(if any).
