### PR TITLE
pascals triangle daily challenge question

### DIFF
--- a/C++/pascals-triangle.cpp
+++ b/C++/pascals-triangle.cpp
@@ -1,0 +1,23 @@
+// runtime : 3ms
+// memory : 6.7 MB
+// complexity : O(n^2)
+
+class Solution {
+public:
+    vector<vector<int>> generate(int numRows) {
+        vector<vector<int>> result(numRows);
+        int k = 0;
+
+        for(int i=0; i<numRows; i++){
+            result[i].resize(i+1);
+            result[i][0] = 1;
+            result[i][k] = 1;
+
+            for(int j=1; j<k; j++){
+                result[i][j] = result[i-1][j-1] + result[i-1][j];
+            }
+            k++;
+        }
+        return result; 
+    }
+};


### PR DESCRIPTION

## [Pascal's Triangle](https://leetcode.com/problems/pascals-triangle/)

**Successfully accepted
Runtime : 3ms
Time Complexity : O(n^2)
Memory : 6.7 MB**

In this problem we have to return first n rows of pascal's triangle. In this triangle each number is sum of the two numbers directly above it.

Intuition :- DP Solution
1) First I have created a vector of vector named as result with the size of n.
2) Then I have iterated a loop till n rows in which I have resized the vector at index i by i+1 size.
3) After resizing the inner vector, I have replaced the current element value by the sum of the two numbers directly above it.
4) Then return the required resultant.


![pascal triangle](https://github.com/codedecks-in/LeetCode-Solutions/assets/73178076/b8c742a9-a1d7-40ec-9183-5286ca4aaa66)
